### PR TITLE
Add subroutine to clear ppu nametables. Call during reset init after …

### DIFF
--- a/src/lib/ppu.s
+++ b/src/lib/ppu.s
@@ -222,3 +222,23 @@ PALETTE     = $3f00
   bne @loop
   rts
 .endproc
+
+.proc clear_nametable_and_attr
+  ldy #4
+  lda #0
+: ldx #0
+: sta PPU_DATA
+  inx
+  bne :-
+  dey
+  bne :--
+  rts
+.endproc
+
+.proc clear_screen
+  Vram NAMETABLE_A
+  jsr clear_nametable_and_attr
+  Vram NAMETABLE_C
+  jsr clear_nametable_and_attr
+  rts
+.endproc

--- a/src/smb-movement.s
+++ b/src/smb-movement.s
@@ -103,6 +103,7 @@
   sta $700, x
   inx
   bne @ram_reset_loop
+  jsr clear_screen
   lda #%11101111
 @sprite_reset_loop:
   sta $200, x


### PR DESCRIPTION
This pull request addresses the issue of garbage appearing in the background when using the compiled ROM on real hardware with an Everdrive N8 Pro.

https://github.com/NesHacker/PlatformerMovement/issues/6

It didn't take me long to put together that something must not be init to zero, and while that is fine on emulators, causes a problem on real hardware. In this demo, only part of the nametable is setup with background tiles, mainly just the ground. The rest is left uninitialized and will point to garbage tiles in the ROM.

You can read more about this behavior here.
https://forums.nesdev.org/viewtopic.php?t=18135

Some emulators such as mesen allow you change the default behavior of the emulator (initializing RAM to zeros) to the default behavior of a real console, leaving the RAM initialized with garbage rather than zeros thereby allowing you to replicate this behavior.

The fix here adds two subroutines I pulled from the NESHacker [nes-pi](https://github.com/NesHacker/NesPi/) repository for clearing the nametables, and i add them to the reset subroutine right after the cpu ram is initialized to zero.

Right now i left it only clearing nametable a and nametable c, this would have to change if you changed the mirroring. I could add another subroutine that clears all nametables as well, which will cover either mirroring setting.